### PR TITLE
{Reviewer: Matt} Fix annoying '/bin/sh: 3: @echo: not found' error message

### DIFF
--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -100,7 +100,7 @@ deb-build:
 deb-move:
 	@if [ "${REPO_DIR}" != "" ] ; then                                                                                     \
 	  if [ "${REPO_SERVER}" != "" ] ; then                                                                                 \
-	    echo Copying to directory ${REPO_DIR} on staging server ${REPO_SERVER}... ;                                                                \
+	    echo Copying to directory ${REPO_DIR} on repo server ${REPO_SERVER}... ;                                                                \
 	    ssh ${REPO_SERVER} mkdir -p '${REPO_DIR}/binary' ;                                                                 \
 	    ssh ${REPO_SERVER} rm -f $(patsubst %, '${REPO_DIR}/binary/%_*', ${DEB_NAMES}) ;                                   \
 	    scp $(patsubst %, ../%_${DEB_VERSION}_${DEB_ARCH}.deb, ${DEB_NAMES}) ${REPO_SERVER}:${REPO_DIR}/binary/ ;          \


### PR DESCRIPTION
Can you review? It looks as though someone used @ in front of "echo" to suppress Makefile printing the command, then added some if statements before that and never removed the original @.
