### PR TITLE
Reviewer Rob - Common C++ build infrastructure

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -1,0 +1,181 @@
+# Common C++ Makefile infrastructure
+#
+# Product specific Makefiles define a list of TARGETS and TEST_TARGETS
+# and then `include` this Makefile.  To customise the build product
+# Makefiles can define the following to tweak the behavior:
+#
+#   target_SOURCES  - List the .cpp files to build (defaults to target.cpp only)
+#   target_CPPFLAGS - Specific flags to pass to the C++ compiler
+#   target_LDFLAGS  - Specific flags to pass to the linker
+
+.DEFAULT_GOAL := all
+.PHONY : all test valgrind vg_check coverage_check coverage_raw clean
+
+# Makefiles can override these if needed
+GTEST_DIR ?= ../modules/gmock/gtest
+GMOCK_DIR ?= ../modules/gmock
+CPP_COMMON_DIR ?= ../modules/cpp-common
+BUILD_DIR ?= ../build
+
+# Common rules to build any target
+#
+# @param $1 - Target name (final executable)
+# @param $2 - Target
+define common_target
+
+# Calculate the object names for the $1 build
+$1_OBJS := $$(patsubst %.cpp,$${BUILD_DIR}/$1/%.o,$${$1_SOURCES})
+$1_DEPS := $$(patsubst %.cpp,$${BUILD_DIR}/$1/%.d,$${$1_SOURCES})
+
+# Create alias for the object directory (for adding custom pre-requisites)
+$1_OBJECT_DIR := $${BUILD_DIR}/$1
+
+# Depend on the depends file so we'll get rebuilt if it's missing
+# (which will have the side effect of re-producing the depends file)
+$${$1_OBJS} : $${$1_OBJECT_DIR}/%.o : %.cpp $${BUILD_DIR}/$1/%.d ${MAKEFILE_LIST}
+	@mkdir -p $${$1_OBJECT_DIR}
+	g++ -MMD -MP $${$2_CPPFLAGS} $${$1_CPPFLAGS} -c $$< -o $$@
+
+# Blank rule for depends files to force the object to be re-built
+# if the depends file is missing (as we don't know if it's out of
+# date or not)
+$${$1_DEPS} : $${$1_OBJECT_DIR}/%.d : ;
+
+# Final linker step for $1
+$${BUILD_DIR}/bin/$1 : $${$1_OBJS}
+	@mkdir -p $${BUILD_DIR}/bin/
+	g++ -o $$@ $$^ $${$2_LDFLAGS} $${$1_LDFLAGS}
+
+# Shortcut alias to make $1
+.PHONY : $1
+$1 : $${BUILD_DIR}/bin/$1
+
+# Include depends files from $1
+DEPENDS += $${$1_DEPS}}
+
+# Clean up for $1
+CLEANS += $${$1_OBJS} $${$1_DEPS} $${BUILD_DIR}/bin/$1
+
+endef
+
+# Extra rules for TEST_TARGETS
+#
+# @param $1 - Target name (final executable)
+define test_target
+
+# Call into standard build infrastructure for $1
+$(call common_target,$1,test)
+
+$${BUILD_DIR}/bin/$1 : $${BUILD_DIR}/obj/gmock-all.o $${BUILD_DIR}/obj/gtest-all.o
+
+.PHONY : run_$1
+run_$1 : $${BUILD_DIR}/bin/$1
+	LD_LIBRARY_PATH=../usr/lib/ $$< ${EXTRA_TEST_ARGS}
+
+# This sentinel file proves the tests have *all* been run on this build (mostly for coverage)
+$${BUILD_DIR}/$1/.$1_already_run : $${BUILD_DIR}/bin/$1
+	LD_LIBRARY_PATH=../usr/lib/ $$<
+	@touch $$@
+
+.PHONY : debug_$1
+debug_$1 : $${BUILD_DIR}/bin/$1
+	LD_LIBRARY_PATH=../usr/lib/ gdb --args $$< $${EXTRA_TEST_ARGS}
+
+$${BUILD_DIR}/$1/valgrind_output.xml : $${BUILD_DIR}/bin/$1
+	LD_LIBRARY_PATH=../usr/lib/ valgrind --xml=yes --xml-file=$$@ $$<
+
+.PHONY : valgrind_check_$1
+valgrind_check_$1 : $${BUILD_DIR}/$1/valgrind_output.xml
+	@mkdir -p $${BUILD_DIR}/scratch/
+	@xmllint --xpath '//error/kind' $$< 2>&1 | \
+		sed -e 's#<kind>##g' | \
+		sed -e 's#</kind>#\n#g' | \
+		sort > $${BUILD_DIR}/scratch/valgrind.tmp
+	@if grep -q -v "XPath set is empty" $${BUILD_DIR}/scratch/valgrind.tmp ; then \
+		echo "Error: some memory errors have been detected" ; \
+		cat $${BUILD_DIR}/scratch/valgrind.tmp ; \
+		echo "See $$< for further details." ; \
+		exit 2 ; \
+	fi
+
+.PHONY : valgrind_$1
+valgrind_$1 : $${BUILD_DIR}/bin/$1
+	LD_LIBRARY_PATH=../usr/lib/ valgrind $$< $${EXTRA_TEST_ARGS}
+
+# Coverage arguments for $1
+$1_COVERAGE_ARGS := --object-directory=$(shell pwd) --root $$(shell pwd) --exclude "^ut" $${$1_OBJECT_DIR}
+
+$${BUILD_DIR}/$1/coverage.xml : $${BUILD_DIR}/$1/.$1_already_run
+	@../modules/gcovr/scripts/gcovr $${$1_COVERAGE_ARGS} --xml > $$@
+
+.PHONY : coverage_check_$1
+coverage_check_$1 : $${BUILD_DIR}/$1/coverage.xml
+	@mkdir -p $${BUILD_DIR}/scratch/
+	@xmllint --xpath '//class[@line-rate!="1.0"]/@filename' $$< \
+		| tr ' ' '\n' \
+		| grep filename= \
+		| cut -d\" -f2 \
+		| sort > $${BUILD_DIR}/scratch/coverage_$1.tmp
+	@sort ut/coverage-not-yet | comm -23 $${BUILD_DIR}/scratch/coverage_$1.tmp - > $${BUILD_DIR}/scratch/coverage_$1_filtered.tmp
+	@if grep -q ^ $${BUILD_DIR}/scratch/coverage_$1_filtered.tmp ; then \
+		echo "Error: some files unexpectedly have less than 100% code coverage:" ; \
+		cat $${BUILD_DIR}/scratch/coverage_$1_filtered.tmp ; \
+		exit 2 ; \
+	fi
+CLEANS += $${BUILD_DIR}/scratch/coverage_$1.tmp $${BUILD_DIR}/scratch/coverage_$1_filtered.tmp
+
+.PHONY : coverage_raw_$1
+coverage_raw_$1 : $${BUILD_DIR}/$1/.$1_already_run
+	@../modules/gcovr/scripts/gcovr $${$1_COVERAGE_ARGS} --keep --sort-percentage
+
+test : run_$1
+valgrind : valgrind_$1
+vg_check : valgrind_check_$1
+coverage_check : coverage_check_$1
+coverage_raw : coverage_raw_$1
+
+CLEANS += $${BUILD_DIR}/$1/valgrind_output.xml $${BUILD_DIR}/$1/.$1_already_run
+
+endef
+
+# Default values for build flags for each build
+__COMMON_CPPFLAGS := -ggdb3 -std=c++11
+release_CPPFLAGS := -O2 ${__COMMON_CPPFLAGS}
+test_CPPFLAGS := -O0 ${__COMMON_CPPFLAGS} -DUNIT_TEST \
+                 -fprofile-arcs -ftest-coverage -fno-access-control\
+								 -I${GTEST_DIR}/include -I${GMOCK_DIR}/include \
+                 -I${CPP_COMMON_DIR}/test_utils
+test_LDFLAGS := -lgcov
+
+ifdef JUSTTEST
+  EXTRA_TEST_ARGS ?= --gtest_filter=*$(JUSTTEST)*
+endif
+
+../build/obj/gmock-all.o : ${GMOCK_DIR}/src/gmock-all.cc ${GMOCK_DIR}/include/gmock/*.h ${GMOCK_DIR}/include/gmock/internal/*.h
+	@mkdir -p ../build/obj
+	${CXX} ${test_CPPFLAGS} -I${GTEST_DIR}/include -I${GMOCK_DIR}/include -I${GMOCK_DIR} -c $< -o $@
+../build/obj/gtest-all.o : ${GTEST_DIR}/src/gtest-all.cc ${GTEST_DIR}/include/gtest/*.h ${GTEST_DIR}/include/gtest/internal/*.h
+	@mkdir -p ../build/obj
+	${CXX} ${test_CPPFLAGS} -I${GTEST_DIR}/include -I${GTEST_DIR}/include -I${GTEST_DIR} -c $< -o $@
+
+# Print out the generate Makefile snippet for debugging purposes
+ifdef DEBUG_MAKEFILE
+$(foreach target,${TARGETS},$(info $(call common_target,${target},release)))
+$(foreach target,${TEST_TARGETS},$(info $(call test_target,${target})))
+$(error Not building since DEBUG_MAKEFILE was specified)
+endif
+
+# Expand the build definitions for each provided target
+$(foreach target,${TARGETS},$(eval $(call common_target,${target},release)))
+$(foreach target,${TEST_TARGETS},$(eval $(call test_target,${target})))
+
+# Build all non-test targets by default
+all : ${TARGETS}
+
+clean :
+	-rm $(sort ${CLEANS}) # make's sort function removes duplicates as a side effect
+
+print-% :
+	@echo $* = $($*)
+
+-include ${DEPENDS}


### PR DESCRIPTION
This adds a common C++ build infrastructure makefile snippet which manages:

* Building release binaries
* Building test binaries
* Running tests
* Running coverage
* Running valgrind
* Managing build dependencies