### PR TITLE
Don't keep raw gcov files

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -148,7 +148,7 @@ CLEANS += $${BUILD_DIR}/scratch/coverage_$1.tmp $${BUILD_DIR}/scratch/coverage_$
 
 .PHONY : coverage_raw_$1
 coverage_raw_$1 : $${BUILD_DIR}/$1/.$1_already_run
-	@${GCOVR_DIR}/scripts/gcovr $${$1_COVERAGE_ARGS} --keep --sort-percentage
+	@${GCOVR_DIR}/scripts/gcovr $${$1_COVERAGE_ARGS} --sort-percentage
 
 test : run_$1
 valgrind : valgrind_$1


### PR DESCRIPTION
After running `make coverage_raw` my directory is filled with `.gcov` files.  Probably not useful.