### PR TITLE
[Already reviewed by Andy] Remove rogue curly brace

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -59,7 +59,7 @@ $${BUILD_DIR}/bin/$1 : $${$1_OBJS}
 $1 : $${BUILD_DIR}/bin/$1
 
 # Include depends files from $1
-DEPENDS += $${$1_DEPS}}
+DEPENDS += $${$1_DEPS}
 
 # Clean up for $1
 CLEANS += $${BUILD_DIR}/bin/$1


### PR DESCRIPTION
This prevented the last .d file being included, which could cause things to not be rebuilt.