### PR TITLE
[Reviewer: Andy] Don't specify /dev/null as the override file

### DIFF
--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -72,7 +72,7 @@ CW_SIGNER ?= maintainers@projectclearwater.org
 CW_SIGNER_REAL := Project Clearwater Maintainers
 
 # Commands to build a package repo.
-CW_BUILD_REPO := dpkg-scanpackages --multiversion binary /dev/null > binary/Packages; \
+CW_BUILD_REPO := dpkg-scanpackages --multiversion binary > binary/Packages; \
                  gzip -9c binary/Packages >binary/Packages.gz;                        \
                  rm -f binary/Release binary/Release.gpg;                             \
                  apt-ftparchive -o APT::FTPArchive::Release::Codename=binary          \


### PR DESCRIPTION
This avoids the slightly annoying:

```
dpkg-scanpackages: warning: Packages in archive but missing from override file:
dpkg-scanpackages: warning:   astaire astaire-dbg astaire-libs ...
```

warning. I've successfully built a set of packages with this.

(Credit to @AME2 who asked why we got that warning, which prompted me to look into it.)