### PR TITLE
[Reviewer: Ellie] Remove old coverage files when re-running tests

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -81,6 +81,7 @@ $1_LD_LIBRARY_PATH ?= ${ROOT}/usr/lib
 
 .PHONY : run_$1
 run_$1 : $${BUILD_DIR}/bin/$1
+	rm -f $${BUILD_DIR}/$1/*.gcda
 	LD_LIBRARY_PATH=$${$1_LD_LIBRARY_PATH} $$< ${EXTRA_TEST_ARGS}
 
 # This sentinel file proves the tests have *all* been run on this build (mostly for coverage)


### PR DESCRIPTION
Like https://github.com/Metaswitch/clearwater-build-infra/commit/3ccfa7a14c27cc3fed52b39585fdd9b7c75e6d95 but runs whenever running tests. This deals with some Clang errors I'm seeing:

`profiling: /home/ubuntu/stats-aggregator/src/../build/stats_aggregator_test/aggregators_test.gcda: cannot merge previous GCDA file: corrupt arc tag (0x73317463)`

which is because the file has changed but I'm trying to update an old coverage file with new data.