### PR TITLE
Reviewer Alex - Allow ommitting TARGETS or TEST_TARGETS

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -188,6 +188,10 @@ ${BUILD_DIR}/obj/gtest-all.o : ${GTEST_DIR}/src/gtest-all.cc ${GTEST_DIR}/includ
 
 CLEAN_DIRS += ${BUILD_DIR}/obj
 
+# In case there are no test/non-test targets for this project
+TARGETS ?=
+TEST_TARGETS ?=
+
 # Print out the generate Makefile snippet for debugging purposes
 ifdef DEBUG_MAKEFILE
 $(foreach target,${TARGETS},$(info $(call common_target,${target},release)))


### PR DESCRIPTION
Rob was complaining that `make full_test` doesn't work projects with no TEST_TARGETS defined, this just defaults those projects to have empty lists for `TARGETS`/`TEST_TARGETS`.