### PR TITLE
[Reviewer: Matt] Allow spec files to be specified separately from output packages

### DIFF
--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -165,8 +165,8 @@ deb-move:
 	      mv $$debug_packages ${REPO_DIR}/binary/ ;                                                                                                  \
 	    fi ;                                                                                                                                         \
 	    cd ${REPO_DIR} ; ${DEB_BUILD_REPO}; cd - >/dev/null ;                                                                                        \
-	  fi                                                                                                                                             \
-	fi
+	  fi ;                                                                                                                                           \
+	fi ;
 
 .PHONY: deb-move-hardened
 deb-move-hardened:
@@ -176,7 +176,7 @@ deb-move-hardened:
 	    ssh ${HARDENED_REPO_SERVER} mkdir -p '${HARDENED_REPO_DIR}/binary' ;                                                                         \
 	    if [ -n "${REPO_DELETE_OLD}" ] ; then                                                                                                        \
 	      ssh ${HARDENED_REPO_SERVER} rm -f $(patsubst %, '${HARDENED_REPO_DIR}/binary/%_*', ${DEB_NAMES})                                           \
-	                                        $(patsubst %, '${HARDENED_REPO_DIR}/binary/%-dbg_*', ${DEB_NAMES})                                       \
+	                                        $(patsubst %, '${HARDENED_REPO_DIR}/binary/%-dbg_*', ${DEB_NAMES}) ;                                     \
 	    fi ;                                                                                                                                         \
 	    scp $(LOCAL_DEB_GLOB) ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ ;                                                                 \
 	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
@@ -188,7 +188,7 @@ deb-move-hardened:
 	    mkdir -p ${HARDENED_REPO_DIR}/binary ;                                                                                                       \
 	    if [ -n "${REPO_DELETE_OLD}" ] ; then                                                                                                        \
 	      rm -f $(patsubst %, ${HARDENED_REPO_DIR}/binary/%_*, ${DEB_NAMES})                                                                         \
-	            $(patsubst %, ${HARDENED_REPO_DIR}/binary/%-dbg_*, ${DEB_NAMES})                                                                     \
+	            $(patsubst %, ${HARDENED_REPO_DIR}/binary/%-dbg_*, ${DEB_NAMES}) ;                                                                   \
 	    fi ;                                                                                                                                         \
 	    mv ${LOCAL_DEB_GLOB} ${HARDENED_REPO_DIR}/binary;                                                                                            \
 	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
@@ -196,5 +196,5 @@ deb-move-hardened:
 	      mv $$debug_packages ${HARDENED_REPO_DIR}/binary/ ;                                                                                         \
 	    fi ;                                                                                                                                         \
 	    cd ${HARDENED_REPO_DIR} ; ${DEB_BUILD_REPO}; cd - >/dev/null ;                                                                               \
-	  fi                                                                                                                                             \
-	 fi
+	  fi ;                                                                                                                                           \
+	 fi ;

--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -134,6 +134,11 @@ endif
 # packages have debug packgages). The code below handles this by usng ls to
 # determine what the matches are, and only carrying on if there are some
 # matches.
+#
+# Some existing projects explicitly list their debug packages in DEB_NAMES.
+# Th3e code copes with this. If we are moving to a remote server, we delete the
+# packages after a successful copy as this avoid copying any debug packages
+# twice.
 LOCAL_DEB_GLOB := $(patsubst %, ../%_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb, ${DEB_NAMES})
 LOCAL_DEB_DBG_GLOB := $(patsubst %, ../%-dbg_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb, ${DEB_NAMES})
 
@@ -147,10 +152,10 @@ deb-move:
 	      ssh ${REPO_SERVER} rm -f $(patsubst %, '${REPO_DIR}/binary/%_*', ${DEB_NAMES})                                                             \
 	                               $(patsubst %, '${REPO_DIR}/binary/%-dbg_*', ${DEB_NAMES});                                                        \
 	    fi ;                                                                                                                                         \
-	    scp ${LOCAL_DEB_GLOB} ${REPO_SERVER}:${REPO_DIR}/binary/ ;                                                                                   \
+	    scp ${LOCAL_DEB_GLOB} ${REPO_SERVER}:${REPO_DIR}/binary/ && rm ${LOCAL_DEB_GLOB} ;                                                           \
 	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
 	    if [ -n "$$debug_packages" ]; then                                                                                                           \
-	      scp $$debug_packages ${REPO_SERVER}:${REPO_DIR}/binary/ ;                                                                                  \
+	      scp $$debug_packages ${REPO_SERVER}:${REPO_DIR}/binary/ && rm $$debug_packages ;                                                           \
 	    fi ;                                                                                                                                         \
 	    ssh ${REPO_SERVER} 'cd ${REPO_DIR} ; ${DEB_BUILD_REPO}' ;                                                                                    \
 	  else                                                                                                                                           \
@@ -178,10 +183,10 @@ deb-move-hardened:
 	      ssh ${HARDENED_REPO_SERVER} rm -f $(patsubst %, '${HARDENED_REPO_DIR}/binary/%_*', ${DEB_NAMES})                                           \
 	                                        $(patsubst %, '${HARDENED_REPO_DIR}/binary/%-dbg_*', ${DEB_NAMES}) ;                                     \
 	    fi ;                                                                                                                                         \
-	    scp $(LOCAL_DEB_GLOB) ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ ;                                                                 \
+	    scp $(LOCAL_DEB_GLOB) ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ && rm ${LOCAL_DEB_GLOB};                                          \
 	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
 	    if [ -n "$$debug_packages" ]; then                                                                                                           \
-	      scp $$debug_packages ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ ;                                                                \
+	      scp $$debug_packages ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ && rm $$debug_packages;                                          \
 	    fi ;                                                                                                                                         \
 	    ssh ${HARDENED_REPO_SERVER} 'cd ${HARDENED_REPO_DIR} ; ${DEB_BUILD_REPO}' ;                                                                  \
 	  else                                                                                                                                           \

--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -127,6 +127,16 @@ endif
 # known_hosts on this server must include $REPO_SERVER's server key, and
 # authorized_keys on $REPO_SERVER must include this server's user key.
 # ssh-copy-id can be used to achieve this.
+
+# Shell globs that match the specified packages, and their associated debug
+# packages, respectively. Note that whike all the items in the first glob
+# should match something, this is not true for the second glob (as not all
+# packages have debug packgages). The code below handles this by usng ls to
+# determine what the matches are, and only carrying on if there are some
+# matches.
+LOCAL_DEB_GLOB := $(patsubst %, ../%_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb, ${DEB_NAMES})
+LOCAL_DEB_DBG_GLOB := $(patsubst %, ../%-dbg_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb, ${DEB_NAMES})
+
 .PHONY: deb-move
 deb-move:
 	@if [ "${REPO_DIR}" != "" ] ; then                                                                                                               \
@@ -134,16 +144,26 @@ deb-move:
 	    echo Copying to directory ${REPO_DIR} on repo server ${REPO_SERVER}... ;                                                                     \
 	    ssh ${REPO_SERVER} mkdir -p '${REPO_DIR}/binary' ;                                                                                           \
 	    if [ -n "${REPO_DELETE_OLD}" ] ; then                                                                                                        \
-	      ssh ${REPO_SERVER} rm -f $(patsubst %, '${REPO_DIR}/binary/%_*', ${DEB_NAMES}) ;                                                           \
+	      ssh ${REPO_SERVER} rm -f $(patsubst %, '${REPO_DIR}/binary/%_*', ${DEB_NAMES})                                                             \
+	                               $(patsubst %, '${REPO_DIR}/binary/%-dbg_*', ${DEB_NAMES});                                                        \
 	    fi ;                                                                                                                                         \
-	    scp $(patsubst %, ../%_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb, ${DEB_NAMES}) ${REPO_SERVER}:${REPO_DIR}/binary/ ;                   \
+	    scp ${LOCAL_DEB_GLOB} ${REPO_SERVER}:${REPO_DIR}/binary/ ;                                                                                   \
+	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
+	    if [ -n "$$debug_packages" ]; then                                                                                                           \
+	      scp $$debug_packages ${REPO_SERVER}:${REPO_DIR}/binary/ ;                                                                                  \
+	    fi ;                                                                                                                                         \
 	    ssh ${REPO_SERVER} 'cd ${REPO_DIR} ; ${DEB_BUILD_REPO}' ;                                                                                    \
 	  else                                                                                                                                           \
 	    mkdir -p ${REPO_DIR}/binary ;                                                                                                                \
 	    if [ -n "${REPO_DELETE_OLD}" ] ; then                                                                                                        \
 	      rm -f $(patsubst %, ${REPO_DIR}/binary/%_*, ${DEB_NAMES}) ;                                                                                \
+	      rm -f $(patsubst %, ${REPO_DIR}/binary/%-dbg_*, ${DEB_NAMES}) ;                                                                            \
 	    fi ;                                                                                                                                         \
-	    for pkg in ${DEB_NAMES} ; do mv ../$${pkg}_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb ${REPO_DIR}/binary; done ;                        \
+	    mv ${LOCAL_DEB_GLOB} ${REPO_DIR}/binary;                                                                                                     \
+	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
+	    if [ -n "$$debug_packages" ]; then                                                                                                           \
+	      mv $$debug_packages ${REPO_DIR}/binary/ ;                                                                                                  \
+	    fi ;                                                                                                                                         \
 	    cd ${REPO_DIR} ; ${DEB_BUILD_REPO}; cd - >/dev/null ;                                                                                        \
 	  fi                                                                                                                                             \
 	fi
@@ -155,16 +175,26 @@ deb-move-hardened:
 	    echo Copying to directory ${HARDENED_REPO_DIR} on repo server ${HARDENED_REPO_SERVER}... ;                                                   \
 	    ssh ${HARDENED_REPO_SERVER} mkdir -p '${HARDENED_REPO_DIR}/binary' ;                                                                         \
 	    if [ -n "${REPO_DELETE_OLD}" ] ; then                                                                                                        \
-	      ssh ${HARDENED_REPO_SERVER} rm -f $(patsubst %, '${HARDENED_REPO_DIR}/binary/%_*', ${DEB_NAMES}) ;                                         \
+	      ssh ${HARDENED_REPO_SERVER} rm -f $(patsubst %, '${HARDENED_REPO_DIR}/binary/%_*', ${DEB_NAMES})                                           \
+	                                        $(patsubst %, '${HARDENED_REPO_DIR}/binary/%-dbg_*', ${DEB_NAMES})                                       \
 	    fi ;                                                                                                                                         \
-	    scp $(patsubst %, ../%_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb, ${DEB_NAMES}) ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ ; \
+	    scp $(LOCAL_DEB_GLOB) ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ ;                                                                 \
+	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
+	    if [ -n "$$debug_packages" ]; then                                                                                                           \
+	      scp $$debug_packages ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/binary/ ;                                                                \
+	    fi ;                                                                                                                                         \
 	    ssh ${HARDENED_REPO_SERVER} 'cd ${HARDENED_REPO_DIR} ; ${DEB_BUILD_REPO}' ;                                                                  \
 	  else                                                                                                                                           \
 	    mkdir -p ${HARDENED_REPO_DIR}/binary ;                                                                                                       \
 	    if [ -n "${REPO_DELETE_OLD}" ] ; then                                                                                                        \
-	      rm -f $(patsubst %, ${HARDENED_REPO_DIR}/binary/%_*, ${DEB_NAMES}) ;                                                                       \
+	      rm -f $(patsubst %, ${HARDENED_REPO_DIR}/binary/%_*, ${DEB_NAMES})                                                                         \
+	            $(patsubst %, ${HARDENED_REPO_DIR}/binary/%-dbg_*, ${DEB_NAMES})                                                                     \
 	    fi ;                                                                                                                                         \
-	    for pkg in ${DEB_NAMES} ; do mv ../$${pkg}_${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}_*.deb ${HARDENED_REPO_DIR}/binary; done ;               \
+	    mv ${LOCAL_DEB_GLOB} ${HARDENED_REPO_DIR}/binary;                                                                                            \
+	    debug_packages=$$(ls -A ${LOCAL_DEB_DBG_GLOB} 2>/dev/null);                                                                                  \
+	    if [ -n "$$debug_packages" ]; then                                                                                                           \
+	      mv $$debug_packages ${HARDENED_REPO_DIR}/binary/ ;                                                                                         \
+	    fi ;                                                                                                                                         \
 	    cd ${HARDENED_REPO_DIR} ; ${DEB_BUILD_REPO}; cd - >/dev/null ;                                                                               \
 	  fi                                                                                                                                             \
 	 fi

--- a/cw-rpm.mk
+++ b/cw-rpm.mk
@@ -43,6 +43,10 @@
 # PKG_NAMES or RPM_NAMES (RPM_NAMES takes precedence)
 #                      - space-separated base names of packages
 #                        (e.g., sprout sprout-dbg)
+# PKG_NAMES or RPM_SPECS (RPM_SPECS takes precedence)
+#                      - space-separated base names of spec files that should
+#                        be built (e.g., sprout). This is needed as some
+#                        specfiles also geenrate debug packages.
 
 # Caller may also set the following:
 # PKG_MINOR_VERSION or RPM_MINOR_VERSION (RPM_MINOR_VERSION takes precedence)
@@ -70,6 +74,7 @@ RPM_COMPONENT ?= $(PKG_COMPONENT)
 RPM_MAJOR_VERSION ?= $(PKG_MAJOR_VERSION)
 RPM_MINOR_VERSION ?= $(PKG_MINOR_VERSION)
 RPM_NAMES ?= $(PKG_NAMES)
+RPM_SPECS ?= $(PKG_NAMES)
 
 RPM_ARCH := $(shell rpmbuild -E %{_arch} 2>/dev/null)
 
@@ -107,7 +112,7 @@ rpm-build:
 	else\
 		echo "- built from revision $$(git rev-parse HEAD)" >>rpm/changelog;\
 	fi
-	for pkg in ${RPM_NAMES} ; do\
+	for pkg in ${RPM_SPECS} ; do\
 		rpmbuild -ba rpm/$${pkg}.spec\
         	         --define "_topdir $(shell pwd)/rpm"\
         	         --define "rootdir $(shell pwd)"\

--- a/cw-rpm.mk
+++ b/cw-rpm.mk
@@ -139,10 +139,10 @@ rpm-move:
 	                               $(patsubst %, '${REPO_DIR}/${RPM_ARCH}/RPMS/%-*', ${RPM_NAMES})                        \
 	                               $(patsubst %, '${REPO_DIR}/${RPM_ARCH}/RPMS/%-debuginfo-*', ${RPM_NAMES}) ;            \
 	    fi ;                                                                                                              \
-	    if ls -A rpm/RPMS/noarch/*.rpm > /dev/null ; then                                                                 \
+	    if ls -A rpm/RPMS/noarch/*.rpm > /dev/null 2>&1; then                                                             \
 	      scp rpm/RPMS/noarch/*.rpm ${REPO_SERVER}:${REPO_DIR}/noarch/RPMS/ ;                                             \
 	    fi ;                                                                                                              \
-	    if ls -A rpm/RPMS/${RPM_ARCH}/*.rpm > /dev/null ; then                                                            \
+	    if ls -A rpm/RPMS/${RPM_ARCH}/*.rpm > /dev/null 2>&1; then                                                        \
 	      scp rpm/RPMS/${RPM_ARCH}/*.rpm ${REPO_SERVER}:${REPO_DIR}/${RPM_ARCH}/RPMS/ ;                                   \
 	    fi ;                                                                                                              \
 	    ssh ${REPO_SERVER} 'cd ${REPO_DIR} ; ${RPM_BUILD_REPO}' ;                                                         \
@@ -176,10 +176,10 @@ rpm-move-hardened:
 	                                        $(patsubst %, '${HARDENED_REPO_DIR}/${RPM_ARCH}/RPMS/%-*', ${RPM_NAMES})      \
 	                                        $(patsubst %, '${HARDENED_REPO_DIR}/${RPM_ARCH}/RPMS/%-debuginfo-*', ${RPM_NAMES}) ; \
 	    fi ;                                                                                                              \
-	    if ls -A rpm/RPMS/noarch/*.rpm > /dev/null ; then                                                                 \
+	    if ls -A rpm/RPMS/noarch/*.rpm > /dev/null 2>&1; then                                                             \
 	      scp rpm/RPMS/noarch/*.rpm ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/noarch/RPMS/ ;                           \
 	    fi ;                                                                                                              \
-	    if ls -A rpm/RPMS/${RPM_ARCH}/*.rpm > /dev/null ; then                                                            \
+	    if ls -A rpm/RPMS/${RPM_ARCH}/*.rpm > /dev/null 2>&1; then                                                        \
 	      scp rpm/RPMS/${RPM_ARCH}/*.rpm ${HARDENED_REPO_SERVER}:${HARDENED_REPO_DIR}/${RPM_ARCH}/RPMS/ ;                 \
 	    fi ;                                                                                                              \
 	    ssh ${HARDENED_REPO_SERVER} 'cd ${HARDENED_REPO_DIR} ; ${RPM_BUILD_REPO}' ;                                       \


### PR DESCRIPTION
HI Matt, 

This PR enhances `cw-rpm.mk` to decouple "which spec files to build" from "which packages to expect have been built". This is needed because of the way debug packages work on centos - the debug package is build from the same spec file as the main package, so you end up with one spec file producing two (differently named) rpms.

I've tested that this works by building a project with a debug package and checking that the debug package is built, and is moved along with the main package if `REPO_DIR` is set. 

Thanks,
Alex.