### PR TITLE
[Reviewer: Matt] RPM build infrastrucure enhancements

### DIFF
--- a/cw-rpm.mk
+++ b/cw-rpm.mk
@@ -43,6 +43,10 @@
 # PKG_NAMES or RPM_NAMES (RPM_NAMES takes precedence)
 #                      - space-separated base names of packages
 #                        (e.g., sprout sprout-dbg)
+# PKG_NAMES or RPM_SPECS (RPM_SPECS takes precedence)
+#                      - space-separated base names of spec files that should
+#                        be built (e.g., sprout). This is needed as some
+#                        specfiles also geenrate debug packages.
 
 # Caller may also set the following:
 # PKG_MINOR_VERSION or RPM_MINOR_VERSION (RPM_MINOR_VERSION takes precedence)
@@ -70,6 +74,7 @@ RPM_COMPONENT ?= $(PKG_COMPONENT)
 RPM_MAJOR_VERSION ?= $(PKG_MAJOR_VERSION)
 RPM_MINOR_VERSION ?= $(PKG_MINOR_VERSION)
 RPM_NAMES ?= $(PKG_NAMES)
+RPM_SPECS ?= $(PKG_NAMES)
 
 RPM_ARCH := $(shell rpmbuild -E %{_arch} 2>/dev/null)
 
@@ -107,7 +112,7 @@ rpm-build:
 	else\
 		echo "- built from revision $$(git rev-parse HEAD)" >>rpm/changelog;\
 	fi
-	for pkg in ${RPM_NAMES} ; do\
+	for pkg in ${RPM_SPECS} ; do\
 		rpmbuild -ba rpm/$${pkg}.spec\
         	         --define "_topdir $(shell pwd)/rpm"\
         	         --define "rootdir $(shell pwd)"\

--- a/cw-rpm.spec.inc
+++ b/cw-rpm.spec.inc
@@ -1,7 +1,5 @@
 Version:        %{RPM_MAJOR_VERSION}
 Release:        %{RPM_MINOR_VERSION}
-License:        "GPLv3+ with exceptions"
-URL:            http://projectclearwater.org
 Packager:       %{RPM_SIGNER_REAL} <%{RPM_SIGNER}>
 AutoReqProv:    no
 


### PR DESCRIPTION
HI Matt,

This PR makes two changes: 

* Decouple "which spec files to build" from "which packages to expect have been built". This is needed because of the way debug packages work on centos - the debug package is build from the same spec file as the main package, so you end up with one spec file producing two (differently named) rpms.
* Move the licensing fields out of the common include file (so that we can use different licenses for different packages). 

I've tested that this works by building a project with a debug package and checking that the debug package is built, and is moved along with the main package if REPO_DIR is set.

Thanks,
Alex.