### PR TITLE
[Reviewer: Matt] Enhance debuginfo packages

### DIFF
--- a/cw-rpm.spec.inc
+++ b/cw-rpm.spec.inc
@@ -10,3 +10,25 @@ AutoReqProv:    no
 
 %changelog
 %(cat rpm/changelog)
+
+# Template for debug information sub-package.
+#
+# This is a redefinition of the standard debug_package macro but with an
+# additional Requires line to depend on the parent package at the correct
+# version, and gdb.
+%define cw_debug_package()\
+%ifnarch noarch\
+%global __debug_package 1\
+%package debuginfo\
+Summary: Debug information for package %{name}\
+Group: Development/Debug\
+AutoReqProv: 0\
+Requires: gdb %{name} = %{version}-%{release}\
+%description debuginfo\
+This package provides debug information for package %{name}.\
+Debug information is useful when developing applications that use this\
+package or when debugging this package.\
+%files debuginfo -f debugfiles.list\
+%defattr(-,root,root)\
+%endif\
+%{nil}


### PR DESCRIPTION
This PR makes debuginfo packages have an explicit versioned dependecy on the parent
package, and also on gdb. 

Most if this is a straight copy of the macro in `debug_package` in `/usr/lib/rpm/macros`. I've changed the name to `cw_debug_package` and added the extra Requires line. 

I'll update the relevant spec files to use the new macro, but won't bother you with those trivial PRs. 

I've checked that installing the debuginfo package also installs gdb. If you upgrade either the main package or the debginfo, both get upgraded. 