### PR TITLE
[Reviewer: Matt] Allow the license and project URL to be overridden

### DIFF
--- a/cw-rpm.spec.inc
+++ b/cw-rpm.spec.inc
@@ -1,11 +1,11 @@
 # Default the License and URL if they are not already specified.
-%{!?LICENSE_VALUE: %define LICENSE_VALUE "GPLv3+ with exceptions" }
-%{!?URL_VALUE: %define URL_VALUE http://projectclearwater.org }
+%{!?RPM_LICENSE: %define RPM_LICENSE "GPLv3+ with exceptions" }
+%{!?RPM_URL: %define RPM_URL http://projectclearwater.org }
 
 Version:        %{RPM_MAJOR_VERSION}
 Release:        %{RPM_MINOR_VERSION}
-License:        %{LICENSE_VALUE}
-URL:            %{URL_VALUE}
+License:        %{RPM_LICENSE}
+URL:            %{RPM_URL}
 Packager:       %{RPM_SIGNER_REAL} <%{RPM_SIGNER}>
 AutoReqProv:    no
 

--- a/cw-rpm.spec.inc
+++ b/cw-rpm.spec.inc
@@ -1,7 +1,11 @@
+# Default the License and URL if they are not already specified.
+%{!?LICENSE_VALUE: %define LICENSE_VALUE "GPLv3+ with exceptions" }
+%{!?URL_VALUE: %define URL_VALUE http://projectclearwater.org }
+
 Version:        %{RPM_MAJOR_VERSION}
 Release:        %{RPM_MINOR_VERSION}
-License:        "GPLv3+ with exceptions"
-URL:            http://projectclearwater.org
+License:        %{LICENSE_VALUE}
+URL:            %{URL_VALUE}
 Packager:       %{RPM_SIGNER_REAL} <%{RPM_SIGNER}>
 AutoReqProv:    no
 


### PR DESCRIPTION
This PR enhances the RPM specfile includes to allow the RPM's license and URL to be overriden. 