### PR TITLE
[Reviewer: MIRW] Incremental build with installed submodules

### DIFF
--- a/cw-module-install.mk
+++ b/cw-module-install.mk
@@ -1,21 +1,26 @@
 # Each submodule installs itself, thus updating timestamps of include and
 # library files.
 #
-# To work around this, we install them elsewhere, and then synchronize them to allow
-# incremental builds to work
-PRE_ROOT := ${ROOT}/build/module-install
-PRE_PREFIX := ${PRE_ROOT}/usr
-PRE_INSTALL_DIR := ${PRE_PREFIX}
-PRE_INCLUDE_DIR := ${PRE_INSTALL_DIR}/include
-PRE_LIB_DIR := ${PRE_INSTALL_DIR}/lib
+# To work around this, we keep a backup of the install dir with correct checksums,
+# and replace the install dir with the ones with the correct checksums.
+BAK_INSTALL_DIR := ${ROOT}/build/module-install/usr
 
+# sync_install can be called repeatedly, idempotently. Each time it will
+# make the install directory have the minimum correct timestamps.
 .PHONY: sync_install
 sync_install:
-	# pkg-config generates files which explcitly refer to the pre synchronized
-	# directory, so we need to fix them up
-	sed -e 's/build\/module-install\///g' -i ${PRE_INSTALL_DIR}/lib/pkgconfig/*.pc
 
-	# rsync using checksums, as the modification time is wrong. This may lead
-	# to false negatives, but they are very unlikely and tricky to workaround
-	rsync --links -v -r --checksum ${PRE_INSTALL_DIR}/ ${INSTALL_DIR}/
+	mkdir -p ${BAK_INSTALL_DIR}
 
+	# First update the backup install dir.
+	#
+	# We use rsync to update all the files whose contents have changed, using
+	# checksums instead of timestamps
+	rsync --links -v -r --checksum --delete ${INSTALL_DIR}/ ${BAK_INSTALL_DIR}/
+
+	# Now update the install dir. First remove the old one with later timestamps
+	rm -rf ${INSTALL_DIR}
+
+	# Copy the backup into it's place. This has the same files, but with earlier
+	# timestamps
+	cp -r --preserve=timestamps ${BAK_INSTALL_DIR}/ ${INSTALL_DIR}/

--- a/cw-module-install.mk
+++ b/cw-module-install.mk
@@ -1,0 +1,21 @@
+# Each submodule installs itself, thus updating timestamps of include and
+# library files.
+#
+# To work around this, we install them elsewhere, and then synchronize them to allow
+# incremental builds to work
+PRE_ROOT := ${ROOT}/build/module-install
+PRE_PREFIX := ${PRE_ROOT}/usr
+PRE_INSTALL_DIR := ${PRE_PREFIX}
+PRE_INCLUDE_DIR := ${PRE_INSTALL_DIR}/include
+PRE_LIB_DIR := ${PRE_INSTALL_DIR}/lib
+
+.PHONY: sync_install
+sync_install:
+	# pkg-config generates files which explcitly refer to the pre synchronized
+	# directory, so we need to fix them up
+	sed -e 's/build\/module-install\///g' -i ${PRE_INSTALL_DIR}/lib/pkgconfig/*.pc
+
+	# rsync using checksums, as the modification time is wrong. This may lead
+	# to false negatives, but they are very unlikely and tricky to workaround
+	rsync --links -v -r --checksum ${PRE_INSTALL_DIR}/ ${INSTALL_DIR}/
+


### PR DESCRIPTION
'Install' submodules to a separate directory and then rsync the changed ones
into place only caring about differing checksums.

As per https://github.com/Metaswitch/sprout/pull/1474