### PR TITLE
Different license in make file

### DIFF
--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -112,9 +112,6 @@ ifneq ($(wildcard $(LICENSE)),)
 	if [ -e debian/copyright.repo ]; then\
 		cp debian/copyright.repo debian/copyright;\
 		echo "" >> debian/copyright;\
-	        echo "Files: *" >> debian/copyright;\
-	        echo "Copyright: Metaswitch Networks" >> debian/copyright;\
-	        echo "License: GPL-3+ with OpenSSL exception" >> debian/copyright;\
 		cat $(LICENSE) >> debian/copyright;\
 	fi
 else

--- a/cw-pkg.mk
+++ b/cw-pkg.mk
@@ -48,4 +48,4 @@ CW_SIGNER_REAL := Project Clearwater Maintainers
 GIT_BRANCH := $(shell branch=$$(git symbolic-ref -q HEAD); branch=$${branch\#\#refs/heads/}; branch=$${branch:-HEAD}; echo $$branch)
 
 SHELL := bash
-LICENSE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))LICENSE
+LICENSE := $(ROOT)/LICENSE


### PR DESCRIPTION
I am not sure where is the LICENSE file path used in cw-deb.mk defined. It's supposed to change from some_repository/clearwater-build-infra/LICENSE to just some_repository/LICENSE.