### PR TITLE
[Reviewer: Seb] Allow makefile to use different licenses than GPL

### DIFF
--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -108,14 +108,14 @@ deb-build:
 		echo "  * build from revision $$(git rev-parse HEAD)" >>debian/changelog;\
 	fi
 	echo " -- $(CW_SIGNER_REAL) <$(CW_SIGNER)>  $$(date -R)" >>debian/changelog
-ifneq ($(wildcard $(LICENSE)),)
+ifneq ($(wildcard $(COPYRIGHT_FILE)),)
 	if [ -e debian/copyright.repo ]; then\
 		cp debian/copyright.repo debian/copyright;\
 		echo "" >> debian/copyright;\
-		cat $(LICENSE) >> debian/copyright;\
+		cat $(COPYRIGHT_FILE) >> debian/copyright;\
 	fi
 else
-	@printf "*******************************************************************************\n*\n* LICENSE file ($(LICENSE)) is missing\n*\n*******************************************************************************\n"
+	@printf "*******************************************************************************\n*\n* COPYING file ($(COPYRIGHT_FILE)) is missing\n*\n*******************************************************************************\n"
 	@exit 1
 endif
 	debuild --no-lintian -b -uc -us

--- a/cw-deb.mk
+++ b/cw-deb.mk
@@ -112,9 +112,6 @@ ifneq ($(wildcard $(LICENSE)),)
 	if [ -e debian/copyright.repo ]; then\
 		cp debian/copyright.repo debian/copyright;\
 		echo "" >> debian/copyright;\
-	        echo "Files: *" >> debian/copyright;\
-	        echo "Copyright: Metaswitch Networks" >> debian/copyright;\
-	        echo "License: GPL-3+ with OpenSSL exception" >> debian/copyright;\
 		cat $(LICENSE) >> debian/copyright;\
 	fi
 else

--- a/cw-pkg.mk
+++ b/cw-pkg.mk
@@ -48,4 +48,4 @@ CW_SIGNER_REAL := Project Clearwater Maintainers
 GIT_BRANCH := $(shell branch=$$(git symbolic-ref -q HEAD); branch=$${branch\#\#refs/heads/}; branch=$${branch:-HEAD}; echo $$branch)
 
 SHELL := bash
-LICENSE := $(ROOT)/LICENSE
+COPYRIGHT_FILE := $(ROOT)/COPYING

--- a/cw-pkg.mk
+++ b/cw-pkg.mk
@@ -48,4 +48,4 @@ CW_SIGNER_REAL := Project Clearwater Maintainers
 GIT_BRANCH := $(shell branch=$$(git symbolic-ref -q HEAD); branch=$${branch\#\#refs/heads/}; branch=$${branch:-HEAD}; echo $$branch)
 
 SHELL := bash
-LICENSE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))LICENSE
+LICENSE := $(ROOT)/LICENSE


### PR DESCRIPTION
To allow the makefile to use different copyright files instead of just GPL. Tested on Sprout chef deployment.