### PR TITLE
Ensure that package-specific rsyslog.d files are copied into place during RPM installation.

### DIFF
--- a/deb2rpm.pl
+++ b/deb2rpm.pl
@@ -118,6 +118,9 @@ EOF
     if (-e "debian/$package.logrotate") {
       print $out "copy_to_buildroot debian/$package.logrotate /etc/logrotate.d $package\n";
     }
+    if (-e "debian/$package.rsyslog") {
+      print $out "copy_to_buildroot debian/$package.rsyslog /etc/rsyslog.d $package.conf\n";
+    }
     if (-e "debian/$package.preinst") {
       print " - Check debian/$package.preinst!\n";
       print $out "echo Check debian/$package.preinst and remove this message! >&2 ; exit 1\n";

--- a/deb2rpm.pl
+++ b/deb2rpm.pl
@@ -102,6 +102,9 @@ EOF
     if (-e "debian/$package.install") {
       print $out "install_to_buildroot < %{rootdir}/debian/$package.install\n";
     }
+    if (-e "debian/$package.links") {
+      print $out "install_links_in_buildroot < %{rootdir}/debian/$package.links\n";
+    }
     if (-e "debian/$package.dirs") {
       print $out "dirs_to_buildroot < %{rootdir}/debian/$package.dirs\n";
     }


### PR DESCRIPTION
As summary - this update allows a package to specify an `<package>.rsyslog` file, which gets copied to `/etc/rsyslog.d/<package>.conf` during RPM installation.