### PR TITLE
Fixing `make rpm` to add the correct licensing information

### DIFF
--- a/cw-rpm.spec.inc
+++ b/cw-rpm.spec.inc
@@ -1,7 +1,3 @@
-# Default the License and URL if they are not already specified.
-%{!?RPM_LICENSE: %define RPM_LICENSE "GPLv3+ with exceptions" }
-%{!?RPM_URL: %define RPM_URL http://projectclearwater.org }
-
 Version:        %{RPM_MAJOR_VERSION}
 Release:        %{RPM_MINOR_VERSION}
 License:        %{RPM_LICENSE}


### PR DESCRIPTION
Updates cw-rpm.mk to correctly set the `LICENSE` and `URL` fields.

I had to have a few goes to get the syntax right to pass the variables around, but I've tested this and it works with the `clearwater-monit` library.

(Apologies about the previous one - looks like I accidentally included some additional commits because the branch I pushed was built on top of `clearwater-core`)