### PR TITLE
[Reviewer: Seb] Add useful stuff to python.mk

### DIFF
--- a/python.mk
+++ b/python.mk
@@ -15,3 +15,14 @@ analysis: env
 	# Files in -x are ignored and only high severity level (-lll) are shown.
 	$(ENV_DIR)/bin/easy_install bandit
 	${ENV_DIR}/bin/bandit -r . -x "${BANDIT_EXCLUDE_LIST}" -lll
+
+# Common definitions
+PYTHON := ${ENV_DIR}/bin/python
+PIP := ${ENV_DIR}/bin/pip
+FLAKE8 := ${ENV_DIR}/bin/flake8
+
+INSTALLER := ${PIP} install --compile \
+                            --no-index \
+                            --upgrade \
+                            --pre \
+                            --force-reinstall


### PR DESCRIPTION
This is being done as part of the Python packaging work.

In order to avoid defining some common Python based definitions in every Makefile, I've put them in python.mk.

See https://github.com/Metaswitch/crest/pull/362 for the context this is being done in.