### PR TITLE
[Reviewer: Richard] Common python build infra

### DIFF
--- a/python.mk
+++ b/python.mk
@@ -151,7 +151,7 @@ clean: envclean pyclean
 
 .PHONY: envclean
 envclean:
-	rm -rf bin .eggs .wheelhouse *_wheelhouse parts .installed.cfg bootstrap.py .downloads .buildout_downloads *.egg *.egg-info
+	rm -rf bin .eggs .wheelhouse *wheelhouse parts .installed.cfg bootstrap.py .downloads .buildout_downloads *.egg *.egg-info
 	rm -rf distribute-*.tar.gz
 	rm -rf $(ENV_DIR)
 

--- a/python.mk
+++ b/python.mk
@@ -135,8 +135,8 @@ envclean:
 
 .PHONY: pyclean
 pyclean:
-	find ${SRC_DIR} -name \*.pyc -exec rm -f {} \;
-	rm -rf ${SRC_DIR}/*.egg-info dist
+	$(if ${CLEAN_SRC_DIR},find ${CLEAN_SRC_DIR} -name \*.pyc -exec rm -f {} \;,)
+	$(if ${CLEAN_SRC_DIR},rm -rf ${CLEAN_SRC_DIR}/*.egg-info dist,)
 	rm -rf build build_*
 	rm -f .coverage
 	rm -rf htmlcov/

--- a/python.mk
+++ b/python.mk
@@ -80,13 +80,23 @@ ${ENV_DIR}/.$1-install-wheels: ${ENV_DIR}/.$1-build-wheels $${$1_REQUIREMENTS}
 
 endef
 
+# Common coverage target.
+# To use this, the following must be defined:
+#     * COVERAGE_SETUP_PY: list of the setup.py files that are run under coverage
+#
+# The following are optional, but will be used if defined:
+#     * COVERAGE_PYTHON_PATH: the PYTHONPATH used for the coverage run
+#     * COMPILER_FLAGS: compiler flags to be used
+#     * COVERAGE_SRC_DIR: the source directory for the coverage run
+#     * COVERAGE_EXCL: excluded files
+#
 .PHONY: coverage
 coverage: ${COVERAGE} ${ENV_DIR}/.wheels-installed
 	rm -rf htmlcov/
 	${COVERAGE} erase
 	# For each setup.py file in COVERAGE_SETUP_PY, run under coverage
 	$(foreach setup, ${COVERAGE_SETUP_PY}, \
-		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run $(if ${COVERAGE_SRC_DIR},--source ${COVERAGE_SRC_DIR},) $(if ${COVERAGE_EXCL},--omit "${COVERAGE_EXCL}",) -a ${setup} test;)
+		$(if ${COVERAGE_PYTHON_PATH},PYTHONPATH=${COVERAGE_PYTHON_PATH},) ${COMPILER_FLAGS} ${COVERAGE} run $(if ${COVERAGE_SRC_DIR},--source ${COVERAGE_SRC_DIR},) $(if ${COVERAGE_EXCL},--omit "${COVERAGE_EXCL}",) -a ${setup} test;)
 	${COVERAGE} combine
 	${COVERAGE} report -m --fail-under 100
 	${COVERAGE} xml

--- a/python.mk
+++ b/python.mk
@@ -35,6 +35,8 @@ ${PYTHON} ${ENV_DIR} ${PIP}:
 	${PIP} install --upgrade pip==9.0.1
 	${PIP} install wheel==0.30.0
 
+# Dummy targets onto which the targets defined in python_component below are
+# added as dependencies.
 ${ENV_DIR}/.wheels-cleaned:
 	touch $@
 

--- a/python.mk
+++ b/python.mk
@@ -17,8 +17,8 @@ FLAKE8 := ${ENV_DIR}/bin/flake8
 COVERAGE := ${ENV_DIR}/bin/coverage
 BANDIT := ${ENV_DIR}/bin/bandit
 
-# If not set, default COVERAGE_SETUP_PY
-COVERAGE_SETUP_PY ?= setup.py
+# If not set, default TEST_SETUP_PY
+TEST_SETUP_PY ?= setup.py
 
 INSTALLER := ${PIP} install --compile \
                             --no-index \

--- a/python.mk
+++ b/python.mk
@@ -99,3 +99,19 @@ analysis: ${BANDIT}
 	# Files in -x are ignored and only high severity level (-lll) are shown.
 	${ENV_DIR}/bin/bandit -r . -x "${BANDIT_EXCLUDE_LIST}" -lll
 
+.PHONY: clean
+clean: envclean pyclean
+
+.PHONY: envclean
+envclean:
+	rm -rf bin .eggs .wheelhouse *_wheelhouse parts .installed.cfg bootstrap.py .downloads .buildout_downloads *.egg *.egg-info
+	rm -rf distribute-*.tar.gz
+	rm -rf $(ENV_DIR)
+
+.PHONY: pyclean
+pyclean:
+	find ${SRC_DIR} -name \*.pyc -exec rm -f {} \;
+	rm -rf ${SRC_DIR}/*.egg-info dist
+	rm -rf build build_*
+	rm -f .coverage
+	rm -rf htmlcov/

--- a/python.mk
+++ b/python.mk
@@ -118,6 +118,7 @@ ${ENV_DIR}/.test-requirements: ${ENV_DIR}/.wheels-installed ${TEST_REQUIREMENTS}
 	# Install the test requirements
 	$(foreach reqs, ${TEST_REQUIREMENTS}, \
 		${PIP} install -r ${reqs};)
+	touch $@
 
 ${COVERAGE}: ${PIP}
 	${PIP} install coverage==4.1

--- a/python.mk
+++ b/python.mk
@@ -86,7 +86,7 @@ coverage: ${COVERAGE} ${ENV_DIR}/.wheels-installed
 	${COVERAGE} erase
 	# For each setup.py file in COVERAGE_SETUP_PY, run under coverage
 	$(foreach setup, ${COVERAGE_SETUP_PY}, \
-		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run --omit "${COVERAGE_EXCL}" -a ${setup} test;)
+		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run --source ${COVERAGE_SRC_DIR} --omit "${COVERAGE_EXCL}" -a ${setup} test;)
 	${COVERAGE} combine
 	${COVERAGE} report -m --fail-under 100
 	${COVERAGE} xml

--- a/python.mk
+++ b/python.mk
@@ -86,7 +86,7 @@ coverage: ${COVERAGE} ${ENV_DIR}/.wheels-installed
 	${COVERAGE} erase
 	# For each setup.py file in COVERAGE_SETUP_PY, run under coverage
 	$(foreach setup, ${COVERAGE_SETUP_PY}, \
-		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run --source ${COVERAGE_SRC_DIR} --omit "${COVERAGE_EXCL}" -a ${setup} test;)
+		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run $(if ${COVERAGE_SRC_DIR},--source ${COVERAGE_SRC_DIR},) $(if ${COVERAGE_EXCL},--omit "${COVERAGE_EXCL}",) -a ${setup} test;)
 	${COVERAGE} combine
 	${COVERAGE} report -m --fail-under 100
 	${COVERAGE} xml

--- a/python.mk
+++ b/python.mk
@@ -17,6 +17,9 @@ FLAKE8 := ${ENV_DIR}/bin/flake8
 COVERAGE := ${ENV_DIR}/bin/coverage
 BANDIT := ${ENV_DIR}/bin/bandit
 
+# If not set, default COVERAGE_SETUP_PY
+COVERAGE_SETUP_PY ?= setup.py
+
 INSTALLER := ${PIP} install --compile \
                             --no-index \
                             --upgrade \

--- a/python.mk
+++ b/python.mk
@@ -14,6 +14,7 @@
 PYTHON := ${ENV_DIR}/bin/python
 PIP := ${ENV_DIR}/bin/pip
 FLAKE8 := ${ENV_DIR}/bin/flake8
+COVERAGE := ${ENV_DIR}/bin/coverage
 BANDIT := ${ENV_DIR}/bin/bandit
 
 INSTALLER := ${PIP} install --compile \
@@ -76,8 +77,22 @@ ${ENV_DIR}/.$1-install-wheels: ${ENV_DIR}/.$1-build-wheels $${$1_REQUIREMENTS}
 
 	touch $$@
 
+
 endef
 
+.PHONY: coverage
+coverage: ${COVERAGE} ${ENV_DIR}/.wheels-installed
+	rm -rf htmlcov/
+	${COVERAGE} erase
+	# For each setup.py file in COVERAGE_SETUP_PY, run under coverage
+	$(foreach setup, ${COVERAGE_SETUP_PY}, \
+		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run --omit "${_COVERAGE_EXCL}" -a ${setup} test;)
+	${COVERAGE} combine
+	${COVERAGE} report -m --fail-under 100
+	${COVERAGE} xml
+
+${COVERAGE}: ${PIP}
+	${PIP} install coverage==4.1
 
 ${FLAKE8}: ${ENV_DIR} ${PIP}
 	${PIP} install flake8

--- a/python.mk
+++ b/python.mk
@@ -66,7 +66,7 @@ ${ENV_DIR}/.wheels-installed: ${ENV_DIR}/.$1-install-wheels
 ${ENV_DIR}/.$1-build-wheels: $${$1_SETUP} $${$1_SOURCES} ${PYTHON}
 	# For each setup.py file, generate the wheel
 	$$(foreach setup, $${$1_SETUP}, \
-		$${$1_FLAGS} ${PYTHON} $${setup} build -b build_$$(subst .py,,$${setup}) bdist_wheel -d $${$1_WHEELHOUSE};)
+		$${$1_FLAGS} ${PYTHON} $${setup} $$(if $${$1_BUILD_DIRS},build -b build_$$(subst .py,,$${setup})) bdist_wheel -d $${$1_WHEELHOUSE};)
 
 	touch $$@
 
@@ -76,7 +76,7 @@ ${ENV_DIR}/.$1-install-wheels: ${ENV_DIR}/.$1-build-wheels $${$1_REQUIREMENTS}
 	$${$1_FLAGS} ${PIP} wheel -w $${$1_WHEELHOUSE} $$(foreach req,$${$1_REQUIREMENTS},-r $${req}) --find-links $${$1_WHEELHOUSE}
 
 	# Install the required dependencies in the local environment
-	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $${$1_WHEELS}  $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
+	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $${$1_WHEELS} $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
 
 	touch $$@
 

--- a/python.mk
+++ b/python.mk
@@ -9,7 +9,6 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-.PHONY: analysis
 
 # Common definitions
 PYTHON := ${ENV_DIR}/bin/python
@@ -17,16 +16,20 @@ PIP := ${ENV_DIR}/bin/pip
 FLAKE8 := ${ENV_DIR}/bin/flake8
 BANDIT := ${ENV_DIR}/bin/bandit
 
+INSTALLER := ${PIP} install --compile \
+                            --no-index \
+                            --upgrade \
+                            --pre \
+                            --force-reinstall
+
 ${PYTHON} ${ENV_DIR} ${PIP}:
 	# Set up a fresh virtual environment and install pip
 	virtualenv --setuptools --python=$(PYTHON_BIN) $(ENV_DIR)
 	$(ENV_DIR)/bin/easy_install "setuptools==24"
 
-${ENV_DIR}/.wheel: ${PIP}
 	# Ensure we have an up to date version of pip with wheel support
 	${PIP} install --upgrade pip==9.0.1
 	${PIP} install wheel==0.30.0
-	touch $@
 
 # Common rules to build a python component
 #
@@ -46,11 +49,14 @@ define python_component
 # The wheelhouse can be overridden if desired
 $1_WHEELHOUSE ?= $1_wheelhouse
 
+.PHONY: build-wheels
 build-wheels: ${ENV_DIR}/.$1-build-wheels
+
+.PHONY: install-wheels
 install-wheels: ${ENV_DIR}/.$1-install-wheels
 
 # Builds the wheels for this target
-${ENV_DIR}/.$1-build-wheels: $${$1_SETUP} $${$1_SOURCES} ${ENV_DIR}/.wheel
+${ENV_DIR}/.$1-build-wheels: $${$1_SETUP} $${$1_SOURCES} ${PYTHON}
 	# For each setup.py file, generate the wheel
 	$$(foreach setup, $${$1_SETUP}, \
 		$${$1_FLAGS} ${PYTHON} $${setup} build -b build_$$(subst .py,,$${setup}) bdist_wheel -d $${$1_WHEELHOUSE};)
@@ -73,26 +79,22 @@ endef
 ${FLAKE8}: ${ENV_DIR} ${PIP}
 	${PIP} install flake8
 
-# TODO may need to add exlude list for etcd makefile
 verify: ${FLAKE8}
 	${FLAKE8} --select=E10,E11,E9,F "${FLAKE8_INCLUDE_DIR}" --exclude "${FLAKE8_EXCLUDE_DIR}"
 
 style: ${FLAKE8}
 	${FLAKE8} --select=E,W,C,N --max-line-length=100 "${FLAKE8_INCLUDE_DIR}"
 
+# TODO the "--show-pep8" option has been removed from flake8
 explain-style: ${FLAKE8}
 	${FLAKE8} --select=E,W,C,N --show-pep8 --first --max-line-length=100 "${FLAKE8_INCLUDE_DIR}"
 
 ${BANDIT}: ${ENV_DIR} ${PIP}
 	${PIP} install bandit
 
+.PHONY: analysis
 analysis: ${BANDIT}
 	# Scanning python code recursively for security issues using Bandit.
 	# Files in -x are ignored and only high severity level (-lll) are shown.
 	${ENV_DIR}/bin/bandit -r . -x "${BANDIT_EXCLUDE_LIST}" -lll
 
-INSTALLER := ${PIP} install --compile \
-                            --no-index \
-                            --upgrade \
-                            --pre \
-                            --force-reinstall

--- a/python.mk
+++ b/python.mk
@@ -86,7 +86,7 @@ coverage: ${COVERAGE} ${ENV_DIR}/.wheels-installed
 	${COVERAGE} erase
 	# For each setup.py file in COVERAGE_SETUP_PY, run under coverage
 	$(foreach setup, ${COVERAGE_SETUP_PY}, \
-		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run --omit "${_COVERAGE_EXCL}" -a ${setup} test;)
+		PYTHONPATH=${COVERAGE_PYTHON_PATH} ${COMPILER_FLAGS} ${COVERAGE} run --omit "${COVERAGE_EXCL}" -a ${setup} test;)
 	${COVERAGE} combine
 	${COVERAGE} report -m --fail-under 100
 	${COVERAGE} xml

--- a/python.mk
+++ b/python.mk
@@ -17,6 +17,72 @@ PIP := ${ENV_DIR}/bin/pip
 FLAKE8 := ${ENV_DIR}/bin/flake8
 BANDIT := ${ENV_DIR}/bin/bandit
 
+${PYTHON} ${ENV_DIR} ${PIP}:
+	# Set up a fresh virtual environment and install pip
+	virtualenv --setuptools --python=$(PYTHON_BIN) $(ENV_DIR)
+	$(ENV_DIR)/bin/easy_install "setuptools==24"
+
+${ENV_DIR}/.wheel: ${PIP}
+	# Ensure we have an up to date version of pip with wheel support
+	${PIP} install --upgrade pip==9.0.1
+	${PIP} install wheel==0.30.0
+	touch $@
+
+# Common rules to build a python component
+#
+# @param $1 - Target name
+#
+# Each target must supply:
+#   - <target>_SETUP        - A list of the setup.py files that the target depends on
+#   - <target>_REQUIREMENTS - A list of the requirements files that the target uses
+#   - <target>_SOURCES      - A list of the python source files that go into the wheel
+#   - <target>_WHEELS       - A list of the wheels that are produced
+#   - <target>_FLAGS        - (Optional) Extra flags to be passed to python commands
+#
+# The location of the wheelhouse can be overridden if desired, by specifying
+# <target>_WHEELHOUSE
+define python_component
+
+# The wheelhouse can be overridden if desired
+$1_WHEELHOUSE ?= $1_wheelhouse
+
+build-wheels: ${ENV_DIR}/.$1-build-wheels
+install-wheels: ${ENV_DIR}/.$1-install-wheels
+
+# Builds the wheels for this target
+${ENV_DIR}/.$1-build-wheels: $${$1_SETUP} $${$1_SOURCES} ${ENV_DIR}/.wheel
+	# For each setup.py file, generate the wheel
+	$$(foreach setup, $${$1_SETUP}, \
+		$${$1_FLAGS} ${PYTHON} $${setup} build -b build_$$(subst .py,,$${setup}) bdist_wheel -d $${$1_WHEELHOUSE};)
+
+	touch $$@
+
+# Downloads required dependencies and installs them in the local environment
+${ENV_DIR}/.$1-install-wheels: ${ENV_DIR}/.$1-build-wheels $${$1_REQUIREMENTS}
+	# Download the required dependencies
+	$${$1_FLAGS} ${PIP} wheel -w $${$1_WHEELHOUSE} $$(foreach req,$${$1_REQUIREMENTS},-r $${req}) --find-links $${$1_WHEELHOUSE}
+
+	# Install the required dependencies in the local environment
+	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $${$1_WHEELS}  $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
+
+	touch $$@
+
+endef
+
+
+${FLAKE8}: ${ENV_DIR} ${PIP}
+	${PIP} install flake8
+
+# TODO may need to add exlude list for etcd makefile
+verify: ${FLAKE8}
+	${FLAKE8} --select=E10,E11,E9,F "${FLAKE8_INCLUDE_DIR}" --exclude "${FLAKE8_EXCLUDE_DIR}"
+
+style: ${FLAKE8}
+	${FLAKE8} --select=E,W,C,N --max-line-length=100 "${FLAKE8_INCLUDE_DIR}"
+
+explain-style: ${FLAKE8}
+	${FLAKE8} --select=E,W,C,N --show-pep8 --first --max-line-length=100 "${FLAKE8_INCLUDE_DIR}"
+
 ${BANDIT}: ${ENV_DIR} ${PIP}
 	${PIP} install bandit
 

--- a/python.mk
+++ b/python.mk
@@ -31,6 +31,12 @@ ${PYTHON} ${ENV_DIR} ${PIP}:
 	${PIP} install --upgrade pip==9.0.1
 	${PIP} install wheel==0.30.0
 
+${ENV_DIR}/.wheels-built:
+	touch $@
+
+${ENV_DIR}/.wheels-installed:
+	touch $@
+
 # Common rules to build a python component
 #
 # @param $1 - Target name
@@ -49,11 +55,8 @@ define python_component
 # The wheelhouse can be overridden if desired
 $1_WHEELHOUSE ?= $1_wheelhouse
 
-.PHONY: build-wheels
-build-wheels: ${ENV_DIR}/.$1-build-wheels
-
-.PHONY: install-wheels
-install-wheels: ${ENV_DIR}/.$1-install-wheels
+${ENV_DIR}/.wheels-built: ${ENV_DIR}/.$1-build-wheels
+${ENV_DIR}/.wheels-installed: ${ENV_DIR}/.$1-install-wheels
 
 # Builds the wheels for this target
 ${ENV_DIR}/.$1-build-wheels: $${$1_SETUP} $${$1_SOURCES} ${PYTHON}
@@ -79,15 +82,13 @@ endef
 ${FLAKE8}: ${ENV_DIR} ${PIP}
 	${PIP} install flake8
 
+.PHONY: verify
 verify: ${FLAKE8}
 	${FLAKE8} --select=E10,E11,E9,F "${FLAKE8_INCLUDE_DIR}" --exclude "${FLAKE8_EXCLUDE_DIR}"
 
+.PHONY: style
 style: ${FLAKE8}
 	${FLAKE8} --select=E,W,C,N --max-line-length=100 "${FLAKE8_INCLUDE_DIR}"
-
-# TODO the "--show-pep8" option has been removed from flake8
-explain-style: ${FLAKE8}
-	${FLAKE8} --select=E,W,C,N --show-pep8 --first --max-line-length=100 "${FLAKE8_INCLUDE_DIR}"
 
 ${BANDIT}: ${ENV_DIR} ${PIP}
 	${PIP} install bandit

--- a/python.mk
+++ b/python.mk
@@ -112,7 +112,7 @@ coverage: ${COVERAGE} ${ENV_DIR}/.test-requirements ${TEST_SETUP_PY}
 		$(if ${TEST_PYTHON_PATH},PYTHONPATH=${TEST_PYTHON_PATH},) ${COMPILER_FLAGS} ${COVERAGE} run $(if ${COVERAGE_SRC_DIR},--source ${COVERAGE_SRC_DIR},) $(if ${COVERAGE_EXCL},--omit "${COVERAGE_EXCL}",) -a ${setup} test;)
 	${COVERAGE} combine
 	${COVERAGE} report -m --fail-under 100
-	${COVERAGE} xml
+	${COVERAGE} html
 
 .PHONY: test
 test: ${ENV_DIR}/.test-requirements ${TEST_SETUP_PY}


### PR DESCRIPTION
Adds more common infrastructure to our python.mk, which allows us to re-use it across repositories.

The commonalized parts are:

* wheel building and installation in now done using the `python_component` macro
* coverage
* verify
* style
* clean

(`explain-style` has been removed as it doesn't work with new versions of `flake8`)

Hopefully the comments are sufficient to explain what this all does. If not, I'll update the comments rather than adding more detail to the PR