### PR TITLE
[Reviewer: Adam] Allow tests to be excluded from Valgrind

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -11,6 +11,8 @@
 # For test targets, there are a few extra customization flags:
 #
 #   <target>_VALGRIND_ARGS - Extra, product specific arguments for Valgrind
+#   <target>_VALGRIND_EXCL - (optional) A Gtest filter to match on tests to be
+#                            excluded from the valgrind check
 #
 # This Makefile snippet defines a few variables that may be useful when adding
 # extra pre-requisites to targets:
@@ -112,7 +114,7 @@ $1_VALGRIND_ARGS += --gen-suppressions=all --leak-check=full --track-origins=yes
 
 .PHONY : valgrind_check_$1
 valgrind_check_$1 : $${BUILD_DIR}/bin/$1
-	LD_LIBRARY_PATH=$${$1_LD_LIBRARY_PATH} valgrind $${$1_VALGRIND_ARGS} --xml=yes --xml-file=$${BUILD_DIR}/$1/valgrind_output.xml $$< $(if ${VALGRIND_EXCL},--gtest_filter="-*DeathTest*:${VALGRIND_EXCL}",--gtest_filter="-*DeathTest*") ${EXTRA_TEST_ARGS}
+	LD_LIBRARY_PATH=$${$1_LD_LIBRARY_PATH} valgrind $${$1_VALGRIND_ARGS} --xml=yes --xml-file=$${BUILD_DIR}/$1/valgrind_output.xml $$< $$(if $${$1_VALGRIND_EXCL},--gtest_filter="-*DeathTest*:$${$1_VALGRIND_EXCL}",--gtest_filter="-*DeathTest*") ${EXTRA_TEST_ARGS}
 	@mkdir -p $${BUILD_DIR}/scratch/
 	@xmllint --xpath '//error/kind' $${BUILD_DIR}/$1/valgrind_output.xml 2>&1 | \
 		sed -e 's#<kind>##g' | \

--- a/cpp.mk
+++ b/cpp.mk
@@ -112,7 +112,7 @@ $1_VALGRIND_ARGS += --gen-suppressions=all --leak-check=full --track-origins=yes
 
 .PHONY : valgrind_check_$1
 valgrind_check_$1 : $${BUILD_DIR}/bin/$1
-	LD_LIBRARY_PATH=$${$1_LD_LIBRARY_PATH} valgrind $${$1_VALGRIND_ARGS} --xml=yes --xml-file=$${BUILD_DIR}/$1/valgrind_output.xml $$< --gtest_filter="-*DeathTest*" ${EXTRA_TEST_ARGS}
+	LD_LIBRARY_PATH=$${$1_LD_LIBRARY_PATH} valgrind $${$1_VALGRIND_ARGS} --xml=yes --xml-file=$${BUILD_DIR}/$1/valgrind_output.xml $$< $(if ${VALGRIND_EXCL},--gtest_filter="-*DeathTest*:${VALGRIND_EXCL}",--gtest_filter="-*DeathTest*") ${EXTRA_TEST_ARGS}
 	@mkdir -p $${BUILD_DIR}/scratch/
 	@xmllint --xpath '//error/kind' $${BUILD_DIR}/$1/valgrind_output.xml 2>&1 | \
 		sed -e 's#<kind>##g' | \


### PR DESCRIPTION
This adds the option to exclude tests from the valgrind check.

This lays the groundwork for https://github.com/Metaswitch/sprout/pull/1948 which allows us to speed up sprout's `make full_test` in most cases

Any target can define a `<target>_VALGRIND_EXCL`, which must be a google test filter that matches on the tests that should be excluded.