### PR TITLE
[Reviewer: Richard] Include coverage_raw on full_test

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -228,7 +228,8 @@ $(foreach target,${TEST_TARGETS},$(eval $(call test_target,${target})))
 all : ${TARGETS}
 
 # Complete test suite, runs all possible test flavours)
-full_test : valgrind_check coverage_check
+# Includes coverage_raw so we get the formatted coverage output
+full_test : valgrind_check coverage_raw coverage_check
 
 clean :
 	@rm -f $(sort ${CLEANS}) # make's sort function removes duplicates as a side effect


### PR DESCRIPTION
This ensures we get formatted coverage output in build logs