### PR TITLE
Remove old line

### DIFF
--- a/python.mk
+++ b/python.mk
@@ -166,7 +166,6 @@ clean: envclean pyclean
 .PHONY: envclean
 envclean:
 	rm -rf ${ROOT}/bin ${ROOT}/.eggs ${ROOT}/.wheelhouse ${ROOT}/*wheelhouse ${ROOT}/parts ${ROOT}/.installed.cfg ${ROOT}/bootstrap.py ${ROOT}/.downloads ${ROOT}/.buildout_downloads ${ROOT}/*.egg ${ROOT}/*.egg-info
-	rm -rf ${ROOT}/distribute-*.tar.gz
 	rm -rf $(ENV_DIR)
 
 .PHONY: pyclean


### PR DESCRIPTION
I tested in python-common, using this version of build-infra, by running the following commands:

- make env
- make clean
- make envclean
- make pyclean

That all worked fine.

Then I ran `find . -name "*dist*"` from the root of python-common, and nothing showed up.