### PR TITLE
[Reviewer: Richard] Python makefile improvements

### DIFF
--- a/python.mk
+++ b/python.mk
@@ -130,7 +130,7 @@ $${$1_WHEELHOUSE}/.build-wheels: $${$1_SETUP} $${$1_SOURCES} $${$1_WHEELHOUSE}/.
 		$${$1_FLAGS} ${PYTHON} $${setup} $$(if $${$1_BUILD_DIRS},build -b ${ROOT}/build_$$(subst .py,,$${setup})) bdist_wheel -d $${$1_WHEELHOUSE} &&) true
 	touch $$@
 
-${ENV_DIR}/.$1-install-wheels: $${$1_WHEELHOUSE}/.download-wheels
+${ENV_DIR}/.$1-install-wheels: $${$1_WHEELHOUSE}/.download-wheels $${$1_WHEELHOUSE}/.build-wheels
   # Install all wheels in the wheelhouse into the virtual env for this component
 	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) $${$1_WHEELS} $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
 	touch $$@

--- a/python.mk
+++ b/python.mk
@@ -98,6 +98,10 @@ COVERAGE_SETUP_PY += $${$1_TEST_SETUP}
 test: $1_test
 endif
 
+# Whenever the test requirements change, we must delete our venv as we may have
+# the wrong requirements installed
+${ENV_DIR}/.env: $${$1_TEST_REQUIREMENTS}
+
 ${ENV_DIR}/.$1-test-requirements: $${$1_TEST_REQUIREMENTS} ${ENV_DIR}/.env
 	# Install the test requirements for this component
 	$$(foreach reqs, $${$1_TEST_REQUIREMENTS}, ${PIP} install -r $${reqs} &&) true

--- a/python.mk
+++ b/python.mk
@@ -103,7 +103,7 @@ $1_WHEELHOUSE ?= $1_wheelhouse
 
 ${ENV_DIR}/.download-external-wheels: $${$1_WHEELHOUSE}/.$1-download-wheels
 ${ENV_DIR}/.install-external-wheels: ${ENV_DIR}/.$1-install-wheels
-${ENV_DIR}/.build-wheels: $$${$1_WHEELHOUSE}/.$1-build-wheels
+${ENV_DIR}/.build-wheels: $${$1_WHEELHOUSE}/.$1-build-wheels
 
 # Whenever the requirements change, we must delete our venv as we may have the
 # wrong requirements installed
@@ -116,19 +116,19 @@ $${$1_WHEELHOUSE}/.wheelhouse_complete: $${$1_WHEELHOUSE}/.$1-download-wheels $$
 # Add this wheelhouse to the wheelhouses target
 wheelhouses: $${$1_WHEELHOUSE}/.wheelhouse_complete
 
-$${$1_WHEELHOUSE}/.$1-clean-wheels: $${$1_REQUIREMENTS} ${ENV_DIR}/.env
+$${$1_WHEELHOUSE}/.clean-wheels: $${$1_REQUIREMENTS} ${ENV_DIR}/.env
 	# Whenever the requirements change, clear out the wheelhouse
 	rm -rf $${$1_WHEELHOUSE}/*
 	mkdir -p $${$1_WHEELHOUSE}
 	touch $$@
 
-$${$1_WHEELHOUSE}/.$1-download-wheels: $${$1_WHEELHOUSE}/.$1-clean-wheels
+$${$1_WHEELHOUSE}/.$1-download-wheels: $${$1_WHEELHOUSE}/.clean-wheels
   # Download the required dependencies for this component
 	$${$1_FLAGS} ${PIP} wheel -w $${$1_WHEELHOUSE} $$(foreach req,$${$1_REQUIREMENTS},-r $${req}) --find-links $${$1_WHEELHOUSE}
 	touch $$@
 
 # Builds the wheels for this component
-$${$1_WHEELHOUSE}/.$1-build-wheels: $${$1_SETUP} $${$1_SOURCES} ${PYTHON} $${$1_WHEELHOUSE}/.$1-clean-wheels
+$${$1_WHEELHOUSE}/.$1-build-wheels: $${$1_SETUP} $${$1_SOURCES} $${$1_WHEELHOUSE}/.clean-wheels
 	# For each setup.py file, generate the wheel
 	$$(foreach setup, $${$1_SETUP}, \
 		$${$1_FLAGS} ${PYTHON} $${setup} $$(if $${$1_BUILD_DIRS},build -b ${ROOT}/build_$$(subst .py,,$${setup})) bdist_wheel -d $${$1_WHEELHOUSE} &&) true

--- a/python.mk
+++ b/python.mk
@@ -136,7 +136,7 @@ $${$1_WHEELHOUSE}/.clean-wheels: $${$1_REQUIREMENTS} ${ENV_DIR}/.env
 	touch $$@
 
 $${$1_WHEELHOUSE}/.download-wheels: $${$1_WHEELHOUSE}/.clean-wheels
-  # Download the required dependencies for this component
+	# Download the required dependencies for this component
 	$${$1_FLAGS} ${PIP} wheel -w $${$1_WHEELHOUSE} $$(foreach req,$${$1_REQUIREMENTS},-r $${req}) --find-links $${$1_WHEELHOUSE}
 	touch $$@
 
@@ -148,12 +148,12 @@ $${$1_WHEELHOUSE}/.build-wheels: $${$1_SETUP} $${$1_SOURCES} $${$1_WHEELHOUSE}/.
 	touch $$@
 
 ${ENV_DIR}/.$1-install-wheels: $${$1_WHEELHOUSE}/.download-wheels
-  # Install all wheels in the wheelhouse into the virtual env for this component
+	# Install all wheels in the wheelhouse into the virtual env for this component
 	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
 	touch $$@
 
 ${ENV_DIR}/.$1-install-built-wheels: $${$1_WHEELHOUSE}/.download-wheels $${$1_WHEELHOUSE}/.build-wheels
-  # Install all wheels in the wheelhouse into the virtual env for this component
+	# Install all wheels in the wheelhouse into the virtual env for this component
 	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) $${$1_WHEELS}
 	touch $$@
 

--- a/python.mk
+++ b/python.mk
@@ -147,13 +147,18 @@ $${$1_WHEELHOUSE}/.build-wheels: $${$1_SETUP} $${$1_SOURCES} $${$1_WHEELHOUSE}/.
 		$${$1_FLAGS} ${PYTHON} $${setup} $$(if $${$1_BUILD_DIRS},build -b ${ROOT}/build_$$(subst .py,,$${setup})) bdist_wheel -d $${$1_WHEELHOUSE} &&) true
 	touch $$@
 
-${ENV_DIR}/.$1-install-wheels: $${$1_WHEELHOUSE}/.download-wheels $${$1_WHEELHOUSE}/.build-wheels
+${ENV_DIR}/.$1-install-wheels: $${$1_WHEELHOUSE}/.download-wheels
   # Install all wheels in the wheelhouse into the virtual env for this component
-	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) $${$1_WHEELS} $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
+	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
+	touch $$@
+
+${ENV_DIR}/.$1-install-built-wheels: $${$1_WHEELHOUSE}/.download-wheels $${$1_WHEELHOUSE}/.build-wheels
+  # Install all wheels in the wheelhouse into the virtual env for this component
+	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) $${$1_WHEELS}
 	touch $$@
 
 # To run the tests, we need to install the dependencies
-${ENV_DIR}/.$1-test-requirements: ${ENV_DIR}/.$1-install-wheels
+${ENV_DIR}/.$1-test-requirements: ${ENV_DIR}/.$1-install-wheels ${ENV_DIR}/.$1-install-built-wheels
 
 endef
 

--- a/python.mk
+++ b/python.mk
@@ -64,7 +64,9 @@ coverage: ${COVERAGE} ${ENV_DIR}/.test-requirements
 	${COVERAGE} erase
 	# For each setup.py file in TEST_SETUP_PY, run under coverage
 	$(foreach setup, ${COVERAGE_SETUP_PY}, \
-		$(if ${TEST_PYTHON_PATH},PYTHONPATH=${TEST_PYTHON_PATH},) ${COMPILER_FLAGS} ${COVERAGE} run $(if ${COVERAGE_SRC_DIR},--source ${COVERAGE_SRC_DIR},) $(if ${COVERAGE_EXCL},--omit "${COVERAGE_EXCL}",) -a ${setup} test &&) true
+		$(if ${TEST_PYTHON_PATH},PYTHONPATH=${TEST_PYTHON_PATH},) ${COMPILER_FLAGS} \
+			${COVERAGE} run $(if ${COVERAGE_SRC_DIR},--source ${COVERAGE_SRC_DIR},) \
+			$(if ${COVERAGE_EXCL},--omit "${COVERAGE_EXCL}",) -a ${setup} test &&) true
 	${COVERAGE} combine
 	${COVERAGE} report -m --fail-under 100
 	${COVERAGE} html
@@ -144,12 +146,16 @@ $${$1_WHEELHOUSE}/.download-wheels: $${$1_WHEELHOUSE}/.clean-wheels
 $${$1_WHEELHOUSE}/.build-wheels: $${$1_SETUP} $${$1_SOURCES} $${$1_WHEELHOUSE}/.clean-wheels
 	# For each setup.py file, generate the wheel
 	$$(foreach setup, $${$1_SETUP}, \
-		$${$1_FLAGS} ${PYTHON} $${setup} $$(if $${$1_BUILD_DIRS},build -b ${ROOT}/build_$$(subst .py,,$${setup})) bdist_wheel -d $${$1_WHEELHOUSE} &&) true
+		$${$1_FLAGS} ${PYTHON} $${setup} \
+			$$(if $${$1_BUILD_DIRS},build -b ${ROOT}/build_$$(subst .py,,$${setup})) \
+			bdist_wheel -d $${$1_WHEELHOUSE} &&) true
 	touch $$@
 
 ${ENV_DIR}/.$1-install-wheels: $${$1_WHEELHOUSE}/.download-wheels
 	# Install all wheels in the wheelhouse into the virtual env for this component
-	${INSTALLER} --find-links=$${$1_WHEELHOUSE} $$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) $$(foreach req,$${$1_REQUIREMENTS},-r $${req})
+	${INSTALLER} --find-links=$${$1_WHEELHOUSE} \
+		$$(if $${$1_EXTRA_LINKS},--find-links=$${$1_EXTRA_LINKS},) \
+		$$(foreach req,$${$1_REQUIREMENTS},-r $${req})
 	touch $$@
 
 ${ENV_DIR}/.$1-install-built-wheels: $${$1_WHEELHOUSE}/.download-wheels $${$1_WHEELHOUSE}/.build-wheels


### PR DESCRIPTION
This is an attempt to rationalise the dependencies of our common python makefile infrastructure.

Key changes:

1. Instead of setting python and pip as dependencies, we now have a sentinel file in the venv (`ENV_DIR/.env`) which indicates that we've installed python, pip and wheel. This is to mitigate the fact that sometimes pip would appear as more recent that some of the other sentinel files, which would cause us to delete the entire venv and hence do a full rebuild

1. Components can now either be added as a full component (which builds a wheel) or a test component (which just provides some test targets). Full components include the test components, but add additional targets on top

1. The dependency structure for tests is:
    * each component or test component adds a `<name>_test` target and a sentinel file target that checks that the test requirements have been installed in the venv
    * the `<name>_test` target is also added to the dummy `test` target, so that `make test` runs all tests
    * the test requirements target is also added to a common test requirements target, which allows the coverage target to depend on this (so all test requirements are installed before running coverage)

1. Coverage has to be done all at once, so there's an explicit list of setup.py files to be run under coverage. This target depends on the common test requirements target, so all test requirements are installed before we try to run coverage.

1. The dependency structure for builds is:
    * there's a common `wheelhouses` target, to which individual components add a `wheelhouse_complete` sentinel file to indicate that they've got a complete wheelhouse
        * this depends on both downloading external dependencies and building the wheels that this component produces
    * There's a sentinel `clean-wheels` file which depends on the requirements file for the component. That way, whenever the requirements change, we delete the wheelhouse. This allows for dependencies to be removed. (Note that we don't actually change requirements very often)
        * each of the build and download targets depend on this, so that we re-populate the wheelhouse once it has been cleaned
    * The build target also depends on all the source files for this component. Whenever these or the setup.py file change, we rebuild the wheel
    * There's also and install-wheels target for each component:
        * this installs all the requirements for the component in the venv
        * we only need this for testing, so we add it as a dependency to the test requirements for this component
    * There's also an install-built-wheels target, which installs wheels that were built for this component in the environment, because we sometimes need to install a wheel that's built by this component (e.g. queue_manager depends on the etcd_shared wheel, which is built when we build queue_manager)


All of this now means:
* if you change a source file, you don't have to redownload wheels
* building debians doesn't require you to install wheels in your venv
* it's all a bit easier to follow