### PR TITLE
[Reviewer: BPA]  Force service tests to run in Docker 

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -96,7 +96,8 @@ service_test:
 ifeq ($2,release)
 .PHONY: service_test_$1
 service_test_$1: service_test_copy_files_$1
-	python3 $${ROOT}/build-infra/run_docker_test.py $${SERVICE_TEST_DIR}
+	mkdir -p $${BUILD_DIR}/service_tests
+	python3 $${ROOT}/build-infra/run_docker_test.py $${SERVICE_TEST_DIR} $${BUILD_DIR}/service_tests
 
 # Shortcut alias
 .PHONY: service_test

--- a/cpp.mk
+++ b/cpp.mk
@@ -83,22 +83,20 @@ clangtidy_$1: $${$1_CLANGTIDY}
 # enforces this. To run service tests, repositories must provide:
 # - a service_tests/ directory at the top level
 # - a Dockerfile in that directory which will run the tests
-# - a copy_files_to_docker_context.sh script in that directory, which is
-#   responsible for copying any necessary files (e.g. the binary and libraries
-#   under test) into the service_test/ directory structure - the Dockerfile
-#   cannot see anything above this directory.
+# - a service_test_copy_files_NAME Makefile target which is responsible for
+#   copying any necessary files (e.g. the binary and libraries under test) into
+#   the service_test/ directory structure - the Dockerfile cannot see anything
+#   above this directory.
+
+.PHONY: service_test_copy_files_$1
+service_test_copy_files_$1:
+
 service_test:
+
 ifeq ($2,release)
 .PHONY: service_test_$1
-service_test_$1: $${BUILD_DIR}/bin/$1
-	if [ -d $${SERVICE_TEST_DIR} ]; then \
-		cd $${SERVICE_TEST_DIR} && \
-		bash -xe ./copy_files_to_docker_context.sh && \
-		docker build -t $(shell whoami)-$$@ . && \
-		docker run -t $(shell whoami)-$$@; \
-		else \
-		echo "No service tests found"; \
-		fi
+service_test_$1: service_test_copy_files_$1
+	python3 $${ROOT}/build-infra/run_docker_test.py $${SERVICE_TEST_DIR}
 
 # Shortcut alias
 .PHONY: service_test

--- a/cpp.mk
+++ b/cpp.mk
@@ -95,7 +95,7 @@ service_test_$1: $${BUILD_DIR}/bin/$1
 		cd $${SERVICE_TEST_DIR} && \
 		bash -xe ./copy_files_to_docker_context.sh && \
 		docker build -t $(shell whoami)-$$@ . && \
-		docker run -t $(shell whoami)-$$@; \
+		docker run -v $$(abspath $${SERVICE_TEST_DIR}/log):/log -t $(shell whoami)-$$@; \
 		else \
 		echo "No service tests found"; \
 		fi

--- a/cpp.mk
+++ b/cpp.mk
@@ -83,7 +83,7 @@ service_test:
 ifeq ($2,release)
 .PHONY: service_test_$1
 service_test_$1: $${BUILD_DIR}/bin/$1
-	if [ -d $${SERVICE_TEST_DIR} ]; then $${SERVICE_TEST_DIR}/service_test_main; else echo "No service tests found"; fi
+	if [ -d $${SERVICE_TEST_DIR} ]; then cd $${SERVICE_TEST_DIR} && ./service_test_main; else echo "No service tests found"; fi
 
 # Shortcut alias
 .PHONY: service_test

--- a/cpp.mk
+++ b/cpp.mk
@@ -83,7 +83,14 @@ service_test:
 ifeq ($2,release)
 .PHONY: service_test_$1
 service_test_$1: $${BUILD_DIR}/bin/$1
-	if [ -d $${SERVICE_TEST_DIR} ]; then cd $${SERVICE_TEST_DIR} && ./service_test_main; else echo "No service tests found"; fi
+	if [ -d $${SERVICE_TEST_DIR} ]; then \
+		cd $${SERVICE_TEST_DIR} && \
+		bash -xe ./copy_files_to_docker_context.sh && \
+		docker build -t $(shell whoami)-$$@ . && \
+		docker run -t $(shell whoami)-$$@; \
+		else \
+		echo "No service tests found"; \
+		fi
 
 # Shortcut alias
 .PHONY: service_test

--- a/cpp.mk
+++ b/cpp.mk
@@ -98,10 +98,6 @@ ifeq ($2,release)
 service_test_$1: service_test_copy_files_$1
 	mkdir -p $${BUILD_DIR}/service_tests
 	python3 $${ROOT}/build-infra/run_docker_test.py $${SERVICE_TEST_DIR} $${BUILD_DIR}/service_tests
-
-# Shortcut alias
-.PHONY: service_test
-service_test: service_test_$1
 endif
 
 CLEANS += $${$1_CLANGTIDY}

--- a/cpp.mk
+++ b/cpp.mk
@@ -79,6 +79,14 @@ CLEAN_DIRS += $${$1_OBJECT_DIR}
 clangtidy_$1: $${$1_CLANGTIDY}
 	cat $${$1_CLANGTIDY}
 
+# Service tests must run under Docker, to provide isolation, and this Makefile
+# enforces this. To run service tests, repositories must provide:
+# - a service_tests/ directory at the top level
+# - a Dockerfile in that directory which will run the tests
+# - a copy_files_to_docker_context.sh script in that directory, which is
+#   responsible for copying any necessary files (e.g. the binary and libraries
+#   under test) into the service_test/ directory structure - the Dockerfile
+#   cannot see anything above this directory.
 service_test:
 ifeq ($2,release)
 .PHONY: service_test_$1

--- a/run_docker_test.py
+++ b/run_docker_test.py
@@ -54,10 +54,10 @@ with open(old_image_id_path, "w") as f:
 try:
     subprocess.check_call(["docker", "build", "-t", docker_image_id, args.service_test_dir])
     subprocess.check_call(["docker", "run",
+                           "--rm",
                            "--name", docker_container_name,
                            "-v", "{}:/log".format(log_dir),
-                           "-t", docker_image_id,
-                           "--rm"])
+                           "-t", docker_image_id])
 finally:
     # Delete the _previous_ image if it still exists, not the one we just built.
     images = subprocess.check_output(["docker", "images", "-q"]).decode()

--- a/run_docker_test.py
+++ b/run_docker_test.py
@@ -58,6 +58,7 @@ try:
 finally:
     # Delete the container we just built.
     subprocess.check_call(["docker", "rm", docker_container_name])
+    images = subprocess.check_output(["docker", "images"]).decode()
     # Delete the _previous_ image, not the one we just built.
-    if old_image_id is not None:
+    if old_image_id is not None and old_image_id in images:
         subprocess.check_call(["docker", "rmi", old_image_id])

--- a/run_docker_test.py
+++ b/run_docker_test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+import uuid
+import subprocess
+from time import sleep
+
+parser = argparse.ArgumentParser(description='Run a service test in Docker')
+parser.add_argument('service_test_dir',
+                    type=str,
+                    help='Path of the service test directory')
+
+args = parser.parse_args()
+
+if not os.path.exists(args.service_test_dir):
+    print("No service tests found")
+    sys.exit(0)
+
+# Generate unique IDs for our image and container, so we can delete them after the test
+docker_image_id = str(uuid.uuid4())
+docker_container_name = str(uuid.uuid4())
+
+# We don't want to delete the image we're building now at the end of this test,
+# though - Docker caches intermediate images, which makes subsequent builds
+# faster, and deleting the image after every test run also deletes the cached
+# intermediate images and slows down tests.
+#
+# Instead, we save off the image ID to a file, and each build deletes the
+# _previous_ image - but only after building a new image, which keeps
+# intermediate images in the cache.
+#
+# This isn't perfect cleanup - if someone does a test and then never works on
+# that repo again, they'll have an image which will never get deleted.
+# Likewise, it's possible to delete or lose track of the
+# service_tests/previous_image_id file.
+old_image_id_path = os.path.join(args.service_test_dir, "previous_image_id")
+old_image_id = None
+
+if os.path.exists(old_image_id_path):
+    with open(old_image_id_path) as f:
+        old_image_id = f.read().strip()
+
+with open(old_image_id_path, "w") as f:
+    f.write(docker_image_id)
+
+try:
+    os.chdir(args.service_test_dir)
+    subprocess.check_call(["docker", "build", "-t", docker_image_id, "."])
+    subprocess.check_call(["docker", "run", "--name", docker_container_name, "-t", docker_image_id])
+finally:
+    # Delete the container we just built.
+    subprocess.check_call(["docker", "rm", docker_container_name])
+    # Delete the _previous_ image, not the one we just built.
+    if old_image_id is not None:
+        subprocess.check_call(["docker", "rmi", old_image_id])


### PR DESCRIPTION
This is a follow-on to https://github.com/Metaswitch/clearwater-build-infra/pull/78.

Previously, components provided a `service_test_main` script which was executed and which could do anything. Now, I've got Docker working in the build system, so they must run under Docker and provide a Dockerfile in their service_tests - the comment provides details.

@richardwhiuk @johadalin 