### PR TITLE
[Reviewer: Krista] Add bandit and clang checks to makefiles

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -21,7 +21,7 @@
 #   CLEAN_DIRS          - All directories listed in this will be removed by `make clean`
 
 .DEFAULT_GOAL := all
-.PHONY : all test full_test valgrind valgrind_check coverage_check coverage_raw clean cppcheck
+.PHONY : all test full_test valgrind valgrind_check coverage_check coverage_raw clean cppcheck analysis
 
 # Makefiles can override these if needed
 ROOT ?= ..
@@ -79,6 +79,16 @@ clangtidy_$1: $${$1_CLANGTIDY}
 	cat $${$1_CLANGTIDY}
 
 CLEANS += $${$1_CLANGTIDY}
+
+.PHONY : cppcheck_$1
+cppcheck_$1 :
+	cppcheck --enable=all --quiet -i ut -I ../include -I ../modules/cpp-common/include .
+
+.PHONY : analysis_$1
+analysis_$1 :
+	echo "lll"
+	make clean
+	scan-build -enable-checker core -enable-checker cplusplus -enable-checker deadcode -enable-checker security -enable-checker unix make
 
 endef
 
@@ -170,10 +180,6 @@ CLEANS += $${BUILD_DIR}/scratch/coverage_$1.tmp $${BUILD_DIR}/scratch/coverage_$
 coverage_raw_$1 : $${BUILD_DIR}/$1/.$1_already_run
 	@${GCOVR_DIR}/scripts/gcovr $${$1_COVERAGE_ARGS} --sort-percentage
 
-.PHONY : cppcheck_$1
-cppcheck_$1 :
-	cppcheck --enable=all --quiet -i ut -I ../include -I ../modules/cpp-common/include .
-
 test : run_$1
 valgrind : valgrind_$1
 valgrind_check : valgrind_check_$1
@@ -181,6 +187,7 @@ coverage_check : coverage_check_$1
 coverage_raw : coverage_raw_$1
 clangtidy: clangtidy_$1
 cppcheck : cppcheck_$1
+analysis : analysis_$1
 
 CLEANS += $${BUILD_DIR}/$1/valgrind_output.xml $${BUILD_DIR}/$1/.$1_already_run
 

--- a/python.mk
+++ b/python.mk
@@ -213,6 +213,11 @@ analysis: ${BANDIT}
 	# Files in -x are ignored. Only issues of medium severity and above (-ll) are shown.
 	${ENV_DIR}/bin/bandit -r . -x "${BANDIT_EXCLUDE_LIST}" -ll
 
+analysis_version: ${BANDIT}
+	@# Report the bandit version used in this analysis. We don't print the
+	@# command as this makes the output more complicated.
+	@${ENV_DIR}/bin/bandit --version
+
 .PHONY: env
 env: ${ENV_DIR}/.pip_${PIP_VERSION}_wheel_${WHEEL_VERSION}
 


### PR DESCRIPTION
This PR adds the cpp analysis command as part of build-infra, and adds analysis_version commands that show the version of the analysis tools used. The cpp analysis target can only be used by the standard builds - however only the standard builds use cpp,mk, so I don't see that as a limitation.

Tested by running the commands over the various repos.

I'll also:
* Change any job in Jenkins that uses cpp.mk to call make analysis rather than the Jenkins script
* Add clang as a test dependency to the cpp repos.
